### PR TITLE
fix: remove surface bg color from secondary nav

### DIFF
--- a/static/app/views/nav/secondary/sections/issues/issuesSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issuesSecondaryNav.tsx
@@ -134,6 +134,5 @@ const StickyBottomSection = styled(SecondaryNav.Section, {
       position: sticky;
       bottom: 0;
       z-index: 1;
-      background: ${p.theme.isChonk ? p.theme.background : p.theme.surface200};
     `}
 `;


### PR DESCRIPTION
there was a white box around "configure alerts" before

<img width="273" height="464" alt="Screenshot 2025-08-19 at 10 19 32 AM" src="https://github.com/user-attachments/assets/aafb3d62-6060-4d0f-baba-8213cccfa054" />
